### PR TITLE
Fix links and typos in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
-#Beispielprojekt Composite Components - KontaktManager
+# Beispielprojekt Composite Components - KontaktManager
 
-Hier finden Sie eine Beispielimplementierung der Composite Components (CoCo) Architektur 
-für C# als Hilfe zur Artikelreihe "CoCo - eine .NET Architektur für die Praxis" aus der dotnetpro (Ausgabe 1/15-3/15).
+Hier finden Sie eine Beispielimplementierung der Composite Components (CoCo) Architektur
+für C# als Hilfe zur Artikelreihe "CoCo - eine .NET Architektur für die Praxis" aus der dotnetpro (Ausgabe 2/15-4/15).
 
-- Teil 1 - Besser mit Plan - http://www.dotnetpro.de/articles/onlinearticle5113.aspx
-- Teil 2 - Nieder mit den Abhängigkeiten - http://www.dotnetpro.de/articles/onlinearticle5146.aspx
-- Teil 3 - Composite Components - http://www.dotnetpro.de/articles/onlinearticle5174.aspx
+- Teil 1 - [Besser mit Plan](https://www.dotnetpro.de/update/architektur/besser-plan-1127120.html)
+- Teil 2 - [Nieder mit den Abhängigkeiten](https://www.dotnetpro.de/update/dotnetpro/nieder-abhaengigkeiten-1133382.html)
+- Teil 3 - [Composite Components](https://www.dotnetpro.de/update/architektur/composite-components-1133444.html)
 
-Das hier gezeigte Beispiel zeigt eine Minimalimplementierung und wird demnächst Schrittweise erweitert.
+Das hier gezeigte Beispiel zeigt eine Minimalimplementierung und wird demnächst schrittweise erweitert.
 
-Sollten Sie weiteres Interesse an dieser Architektur haben, besuchen Sie meinen Blog www.david-tielke.de 
-für weiter Artikel und Neuigkeiten zu diesem Thema.
+Sollten Sie weiteres Interesse an dieser Architektur haben, besuchen Sie meinen Blog www.david-tielke.de
+für weitere Artikel und Neuigkeiten zu diesem Thema.
 
-Weitere Fragen zum Thema oder zu Beratungs- und Schulungsleistungen können Sie mir gerne unter 
+Weitere Fragen zum Thema oder zu Beratungs- und Schulungsleistungen können Sie mir gerne unter
 mail@david-tielke.de zukommen lassen.
 
 - Update 04-08-2015: MSTest Unit-Test Projekt mit MOQ hinzugefügt.
 
 Viel Erfolg mit den CoCos!
-


### PR DESCRIPTION
Da die Urls leider nicht auf die erwähnten Artikel verweisen, habe ich sie aktualisiert. Offenbar sind die Artikel in den Heften 2/15 - 4/15, daher habe ich das auch geändert. Zusätzlich wurden zwei Tippfehler ausgebessert und die Überschrift sowie die Links an die Markdown Syntax angepasst. Ich hoffe, die Änderungen sind in Ihrem Sinne!